### PR TITLE
Add Windows ARM 64 build to GitHub release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,18 @@ jobs:
           echo "CFLAGS=--target=aarch64-pc-windows-msvc" >> $env:GITHUB_ENV
           echo "CXXFLAGS=--target=aarch64-pc-windows-msvc /EHsc" >> $env:GITHUB_ENV
 
+      - name: Verify Secret Presence
+        shell: bash
+        run: |
+          if [ -z "$KEY" ]; then
+            echo "ERROR: TAURI_SIGNING_PRIVATE_KEY is EMPTY"
+            exit 1
+          else
+            echo "SUCCESS: Secret detected (Length: ${#KEY})"
+          fi
+        env:
+          KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+
       - name: Build + sign + bundle (CPU ${{ matrix.arch }})
         id: tauri_build
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,8 +92,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: parla-${{ matrix.arch }}-installer
-          path: ${{ join(fromJSON(steps.tauri_build.outputs.artifactPaths), '
-') }}
+          path: src-tauri/target/${{ matrix.rust-target }}/release/bundle/nsis/
           if-no-files-found: error
 
   # NOTE : GitHub's public windows-latest runner (4 cores, 16 GB, 14 GB

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,18 +80,6 @@ jobs:
           echo "CFLAGS=--target=aarch64-pc-windows-msvc" >> $env:GITHUB_ENV
           echo "CXXFLAGS=--target=aarch64-pc-windows-msvc /EHsc" >> $env:GITHUB_ENV
 
-      - name: Verify Secret Presence
-        shell: bash
-        run: |
-          if [ -z "$KEY" ]; then
-            echo "ERROR: TAURI_SIGNING_PRIVATE_KEY is EMPTY"
-            exit 1
-          else
-            echo "SUCCESS: Secret detected (Length: ${#KEY})"
-          fi
-        env:
-          KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-
       - name: Build + sign + bundle (CPU ${{ matrix.arch }})
         id: tauri_build
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,30 @@ permissions:
   contents: write
 
 jobs:
-  # CPU variant - canonical build. Produces the signed installers + the
-  # updater artifacts (latest.json + .sig files). The Tauri updater in the
+  # CPU variants (x64 + ARM64). Produces signed installers + updater
+  # artifacts (latest.json + .sig files). The Tauri updater in the
   # installed app points to this job's latest.json.
+  #
+  # gpu-detect is disabled on ARM64 (--no-default-features) because
+  # NVIDIA does not ship nvml.dll for Windows ARM64. All other features
+  # (whisper.cpp, llama.cpp, ONNX Runtime, WASAPI audio, etc.) compile
+  # natively for both architectures.
   cpu:
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-latest
+            rust-target: x86_64-pc-windows-msvc
+            cargo-args: ""
+          - arch: arm64
+            runner: windows-11-arm
+            rust-target: aarch64-pc-windows-msvc
+            cargo-args: "--no-default-features"
+
+    name: cpu (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,12 +45,14 @@ jobs:
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
           workspaces: "./src-tauri -> target"
-          key: cpu
+          key: cpu-${{ matrix.arch }}
 
       - name: Install npm dependencies
         run: npm ci
@@ -43,7 +64,8 @@ jobs:
           $conf.bundle.createUpdaterArtifacts = $true
           $conf | ConvertTo-Json -Depth 20 | Set-Content src-tauri/tauri.conf.json -Encoding UTF8
 
-      - name: Build + sign + bundle (CPU)
+      - name: Build + sign + bundle (CPU ${{ matrix.arch }})
+        id: tauri_build
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,12 +77,24 @@ jobs:
           releaseBody: |
             See the [changelog](https://github.com/LitteRabbit-37/Parla/blob/main/CHANGELOG.md) for details.
 
-            This release ships only the CPU variant. `Parla_x.y.z_x64-setup.exe` runs Whisper, Parakeet and llama.cpp on CPU and works on every Windows 10 / 11 machine. Auto-updater is wired via `latest.json` so future releases install themselves.
+            This release ships CPU variants for both x64 and ARM64:
+            - `Parla_x.y.z_x64-setup.exe` — for standard x86-64 Windows PCs
+            - `Parla_x.y.z_arm64-setup.exe` — for Windows on ARM devices (Snapdragon, etc.)
+
+            Both variants run Whisper, Parakeet and llama.cpp on CPU and work on every Windows 10 / 11 machine of their respective architecture. Auto-updater is wired via `latest.json` so future releases install themselves.
 
             Users with an NVIDIA GPU who want CUDA acceleration can build Parla themselves from source - see [BUILDING.md](https://github.com/LitteRabbit-37/Parla/blob/main/BUILDING.md#cuda-build) for the recipe.
           releaseDraft: true
           prerelease: false
-          args: --target x86_64-pc-windows-msvc
+          args: --target ${{ matrix.rust-target }} ${{ matrix.cargo-args }}
+
+      - name: Upload ${{ matrix.arch }} artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: parla-${{ matrix.arch }}-installer
+          path: ${{ join(fromJSON(steps.tauri_build.outputs.artifactPaths), '
+') }}
+          if-no-files-found: error
 
   # NOTE : GitHub's public windows-latest runner (4 cores, 16 GB, 14 GB
   # disk) is too small to compile whisper.cpp CUDA + llama.cpp CUDA +

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,14 @@ jobs:
           $conf.bundle.createUpdaterArtifacts = $true
           $conf | ConvertTo-Json -Depth 20 | Set-Content src-tauri/tauri.conf.json -Encoding UTF8
 
+      - name: Use Clang for ARM64 native C/C++ (ggml requirement)
+        if: matrix.arch == 'arm64'
+        shell: pwsh
+        run: |
+          echo "CC=clang-cl" >> $env:GITHUB_ENV
+          echo "CXX=clang-cl" >> $env:GITHUB_ENV
+          echo "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+
       - name: Build + sign + bundle (CPU ${{ matrix.arch }})
         id: tauri_build
         uses: tauri-apps/tauri-action@v0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           - arch: arm64
             runner: windows-11-arm
             rust-target: aarch64-pc-windows-msvc
-            cargo-args: "--no-default-features"
+            cargo-args: "-- --no-default-features"
 
     name: cpu (${{ matrix.arch }})
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           echo "CXX=clang-cl" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
           echo "CFLAGS=--target=aarch64-pc-windows-msvc" >> $env:GITHUB_ENV
-          echo "CXXFLAGS=--target=aarch64-pc-windows-msvc" >> $env:GITHUB_ENV
+          echo "CXXFLAGS=--target=aarch64-pc-windows-msvc /EHsc" >> $env:GITHUB_ENV
 
       - name: Build + sign + bundle (CPU ${{ matrix.arch }})
         id: tauri_build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,12 @@ jobs:
           $conf.bundle.createUpdaterArtifacts = $true
           $conf | ConvertTo-Json -Depth 20 | Set-Content src-tauri/tauri.conf.json -Encoding UTF8
 
+      - name: Setup MSVC ARM64 developer environment
+        if: matrix.arch == 'arm64'
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: arm64
+
       - name: Use Clang for ARM64 native C/C++ (ggml requirement)
         if: matrix.arch == 'arm64'
         shell: pwsh
@@ -71,6 +77,8 @@ jobs:
           echo "CC=clang-cl" >> $env:GITHUB_ENV
           echo "CXX=clang-cl" >> $env:GITHUB_ENV
           echo "CMAKE_GENERATOR=Ninja" >> $env:GITHUB_ENV
+          echo "CFLAGS=--target=aarch64-pc-windows-msvc" >> $env:GITHUB_ENV
+          echo "CXXFLAGS=--target=aarch64-pc-windows-msvc" >> $env:GITHUB_ENV
 
       - name: Build + sign + bundle (CPU ${{ matrix.arch }})
         id: tauri_build

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -57,8 +57,18 @@ This produces:
 
 To build Parla natively for Windows on ARM (Snapdragon X, etc.):
 
-```bash
+### Prerequisites for ARM64
+
+- **Clang/LLVM tools**: In the Visual Studio Installer, under \"Desktop development with C++\", ensure \"C++ Clang Compiler for Windows\" and \"MSBuild support for LLVM toolset\" are checked. The ggml library (used by whisper.cpp and llama.cpp) does not support MSVC on ARM64 — it requires Clang.
+- **Ninja**: Install via `choco install ninja`, or ensure it is available from the Visual Studio installation.
+
+### Build
+
+```powershell
 rustup target add aarch64-pc-windows-msvc
+$env:CC = "clang-cl"
+$env:CXX = "clang-cl"
+$env:CMAKE_GENERATOR = "Ninja"
 npm run tauri build -- --target aarch64-pc-windows-msvc -- --no-default-features
 ```
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -59,7 +59,7 @@ To build Parla natively for Windows on ARM (Snapdragon X, etc.):
 
 ```bash
 rustup target add aarch64-pc-windows-msvc
-npm run tauri build -- --target aarch64-pc-windows-msvc --no-default-features
+npm run tauri build -- --target aarch64-pc-windows-msvc -- --no-default-features
 ```
 
 This produces:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -53,6 +53,24 @@ This produces:
 - `src-tauri/target/release/parla.exe` - the standalone binary
 - `src-tauri/target/release/bundle/nsis/Parla_x.y.z_x64-setup.exe` - NSIS installer (the only bundle target we ship; it prompts for data removal on uninstall and lets the user opt out of the desktop shortcut)
 
+## ARM64 build
+
+To build Parla natively for Windows on ARM (Snapdragon X, etc.):
+
+```bash
+rustup target add aarch64-pc-windows-msvc
+npm run tauri build -- --target aarch64-pc-windows-msvc --no-default-features
+```
+
+This produces:
+
+- `src-tauri/target/aarch64-pc-windows-msvc/release/parla.exe` - the standalone binary
+- `src-tauri/target/aarch64-pc-windows-msvc/release/bundle/nsis/Parla_x.y.z_arm64-setup.exe` - NSIS installer
+
+`--no-default-features` disables `gpu-detect` (the `nvml-wrapper` crate) because NVIDIA does not ship `nvml.dll` for Windows ARM64. All other functionality (Whisper, Parakeet, llama.cpp, audio capture, etc.) works natively on ARM64.
+
+The CI workflow `.github/workflows/release.yml` builds the ARM64 variant automatically on GitHub's `windows-11-arm` runner.
+
 ## Cargo features
 
 Parla exposes several Cargo features in `src-tauri/Cargo.toml` that control backend capabilities:
@@ -66,7 +84,7 @@ Parla exposes several Cargo features in `src-tauri/Cargo.toml` that control back
 | `cuda-onnx` | no | Enable the ONNX Runtime CUDA Execution Provider for Parakeet |
 | `directml-onnx` | no | Enable the ONNX Runtime DirectML EP (AMD / Intel GPU) |
 
-The CI workflow `.github/workflows/release.yml` only builds the CPU variant. The GitHub public `windows-latest` runner (4 cores, 16 GB RAM, 14 GB disk) cannot fit the CUDA build of whisper.cpp + llama.cpp + ggml-cuda within the 6 hour job limit - nvcc and MSBuild oversubscribe the machine and swap-thrash until the job dies. If you need CUDA, build it yourself from source with the recipe below.
+The CI workflow `.github/workflows/release.yml` builds CPU variants for both x64 and ARM64. The GitHub public `windows-latest` runner (4 cores, 16 GB RAM, 14 GB disk) cannot fit the CUDA build of whisper.cpp + llama.cpp + ggml-cuda within the 6 hour job limit - nvcc and MSBuild oversubscribe the machine and swap-thrash until the job dies. If you need CUDA, build it yourself from source with the recipe below.
 
 ## CUDA build
 

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -9,3 +9,6 @@
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "link-args=/FORCE:MULTIPLE /IGNORE:4006 /IGNORE:4088"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/FORCE:MULTIPLE /IGNORE:4006 /IGNORE:4088"]


### PR DESCRIPTION
With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, recently released Snapdragon X2 devices and soon to be released Nvidia N1X SOC users are increasingly expecting native applications.

Modified GitHub build action to create a Windows ARM artifact.

Built and tested installer on my fork on a Snapdragon X2 Elite Extreme Asus Zenbook A16 running Windows 11 ARM 26H1.